### PR TITLE
rules.mk.in: fix bad arguments generating Makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,6 @@ install: all
 	  fi; \
 	done
 
-depend:
-	@for mdir in $(SUBDIRS); do \
-	  if test ! -f $$mdir/Makefile.PL; then \
-	    $(MAKE) -C $$mdir depend; \
-	  fi; \
-	done
-
 newdepend: killdepend
 	@echo "*******************************************"
 	@echo "** Building dependencies..."

--- a/rules.mk.in
+++ b/rules.mk.in
@@ -167,7 +167,7 @@ Makefile.depends: $(NEOTONIC_ROOT)/rules.mk Makefile
 	@touch Makefile.depends
 	@if test "x" != "x$(SOURCE_FILES)"; then \
 	  for II in "$(SOURCE_FILES)"; do \
-		gcc -M -MG ${CFLAGS} $$II >> Makefile.depends; \
+		$(CC) -M -MG $(CFLAGS) $$II >> Makefile.depends; \
 	  done; \
 	 fi
 	@echo "** (done) "


### PR DESCRIPTION
If the path to zlib.h is passed in through CFLAGS (for example, via
--sysroot), then the generated Makefile dependencies may ignore it.

| make[1]: *** No rule to make target 'zlib.h', needed by 'cgi.o'.  Stop.
| make[1]: *** Waiting for unfinished jobs....
| Makefile:29: recipe for target 'cs' failed