### PR TITLE
neo_misc.h: Prefer GNU C variadic macro extension

### DIFF
--- a/util/neo_misc.h
+++ b/util/neo_misc.h
@@ -63,10 +63,10 @@
 
 /* Technically, we could do this in configure and detect what their compiler
  * can handle, but for now... */
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#define USE_C99_VARARG_MACROS 1
-#elif __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 4) || defined (S_SPLINT_S) || defined (COMPILER_GCC4)
+#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 4) || defined (S_SPLINT_S) || defined (COMPILER_GCC4)
 #define USE_GNUC_VARARG_MACROS 1
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define USE_C99_VARARG_MACROS 1
 #else
 #error The compiler is missing support for variable-argument macros.
 #endif


### PR DESCRIPTION
Use the GNU C variadic macro extension if it's available, since it's
more flexibile in the use cases it allows.

Previous versions of gcc 4.9 defaulted to a standard prior to C99,
which caused us to favor USE_GNUC_VARARG_MACROS since __STDC_VERSION__
was not defined.  However, gcc 5.2 defaults to -std=gnu11, and also
defines __STDC_VERSION__ as 201112L, which favors USE_C99_VARARG_MACROS
since that case is checked first.

However, several usages of nerr_raise() do not appear to be compliant
with the C99 standard.  The original intent of USE_C99_VARARG_MACROS
is unclear, so prefer the other.

For example...

In file included from neo_files.c:26:0:
neo_files.c: In function 'ne_listdir_fmatch':
neo_err.h:88:69: error: expected expression before ')' token
    nerr_raisef(__PRETTY_FUNCTION__,__FILE__,__LINE__,e,f,__VA_ARGS__)
                                                                         ^
neo_files.c:219:12: note: in expansion of macro 'nerr_raise'
    return nerr_raise(NERR_ASSERT, "Invalid call to ne_listdir_fmatch");